### PR TITLE
Fix ansible and tidy deploy script

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -142,7 +142,9 @@
         state: absent
 
     - name: Remove old wheels
-      shell: rm /srv/shakenfist/shakenfist-*-py3-none-any.whl
+      file:
+        path: /srv/shakenfist/shakenfist-*-py3-none-any.whl
+        state: absent
 
     - name: Copy shakenfist
       synchronize:

--- a/ansible/deployandtest.sh
+++ b/ansible/deployandtest.sh
@@ -1,8 +1,45 @@
 #!/bin/bash -ex
+#
+# ./deployandtest.sh [aws|gcp|metal|openstack]
+#
+#
+# Note: Tests can skipped by setting $SKIP_SF_TESTS
+#
 
+#### Required settings
+CLOUD=$1
+if [ -z "$CLOUD"]
+then
+  echo ==== CLOUD must be specified: aws, gcp, metal, openstack
+  exit 1
+fi
+
+if [ "$CLOUD" == "gcp" ] && [ -z "$GCP_PROJECT" ]
+then
+  echo ===== Must specify GCP project in \$GCP_PROJECT
+  exit 1
+else
+  VARIABLES="$VARIABLES project=$GCP_PROJECT"
+fi
+
+#### Default settings
+BOOTDELAY="${BOOTDELAY:-2}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-Ukoh5vie}"
+FLOATING_IP_BLOCK="${FLOATING_IP_BLOCK:-10.10.0.0/24}"
+UNIQIFIER="${UNIQIFIER:-$USER"-"`date "+%y%m%d"`"-"`pwgen --no-capitalize -n1`"-"}"
+
+
+# Setup variables for consumption by ansible and terraform
 cwd=`pwd`
 TERRAFORM_VARS="-var=uniqifier=$UNIQIFIER"
-ANSIBLE_VARS="cloud=$CLOUD bootdelay=$BOOTDELAY ansible_root=$cwd uniqifier=$UNIQIFIER"
+
+ANSIBLE_VARS="$ANSIBLE_VARS cloud=$CLOUD"
+ANSIBLE_VARS="$ANSIBLE_VARS bootdelay=$BOOTDELAY"
+ANSIBLE_VARS="$ANSIBLE_VARS ansible_root=$cwd"
+ANSIBLE_VARS="$ANSIBLE_VARS uniqifier=$UNIQIFIER"
+ANSIBLE_VARS="$ANSIBLE_VARS ADMIN_PASSWORD=$ADMIN_PASSWORD"
+ANSIBLE_VARS="$ANSIBLE_VARS floating_network_ipblock=$FLOATING_IP_BLOCK"
+
 for var in $VARIABLES
 do
   TERRAFORM_VARS="$TERRAFORM_VARS -var=$var"


### PR DESCRIPTION
Minor fix that stops new deployments.
Start a conversation about the deploy script. I'm sure you had other ideas.

Importantly I want to ensure that all required settings are always captured in the deployandtest.sh script. Preferably with a default.

(I was caught out finding multiple new variables, each time requiring a deploy run.)