### PR TITLE
Add link in ansible-ci for terraform scripts

### DIFF
--- a/ansible-ci/terraform
+++ b/ansible-ci/terraform
@@ -1,0 +1,1 @@
+../ansible/terraform/


### PR DESCRIPTION
Deploy tests are broken for metal and GCP.
This fixes GCP.

Is this correct??

Metal is still broken and will get an issue.