### PR TITLE
Reduction of scraped metrics to reduce load on push gateway

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -255,6 +255,10 @@
                         '{{hostvars[svr]['node_ip']}}:13001',
                       {% endfor %}
                     ]
+              metric_relabel_configs:
+                - source_labels: [__name__]
+                  regex: '(python\w*|process_\w*)'
+                  action: drop
             - job_name: 'etcd'
               static_configs:
                 - targets: [
@@ -262,7 +266,10 @@
                         '{{hostvars[svr]['node_ip']}}:2379',
                       {% endfor %}
                     ]
-
+              metric_relabel_configs:
+                - source_labels: [__name__]
+                  regex: (?i)(etcd_mvcc_db_total_size_in_bytes|etcd_network_client_grpc_received_bytes_total|etcd_network_client_grpc_sent_bytes_total)
+                  action: keep
           {{prom_additional}}
         dest: /etc/prometheus/prometheus.yml
         owner: root


### PR DESCRIPTION
Whitelist etcd metrics due to sheer number of metrics /metrics endpoint has by default.
Blacklist shakenfist metric label groups that aren't used. Will need to engineer a better solution as metric solution matures.

