### PR TITLE
add support for Ubuntu Focal, set deps as variable

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -6,6 +6,8 @@
     release: git
 
   tasks:
+    - include_tasks: tasks/distro-check.yml
+
     - name: Ensure unit tests pass
       shell:
         cmd: tox -epy3
@@ -114,6 +116,9 @@
         enabled: yes
         state: restarted
       when: hostvars['localhost']['database_node_ip'] != node_ip
+
+    - name: Load default vars
+      include_vars: main.yml
 
     - include: includes/debian.yml
 

--- a/ansible/includes/ansible.yml
+++ b/ansible/includes/ansible.yml
@@ -7,6 +7,7 @@
 - name: Add ansible PPA repository
   apt_repository:
     repo: "ppa:ansible/ansible"
+  when: ansible_distribution_version < '20.04'
 
 - name: Install ansible
   apt:

--- a/ansible/includes/debian.yml
+++ b/ansible/includes/debian.yml
@@ -7,27 +7,7 @@
 
 - name: Install dependancies
   apt:
-    name:
-      [
-        "arping",
-        "bridge-utils",
-        "cpu-checker",
-        "dnsmasq",
-        "dnsutils",
-        "etcd-client",
-        "git",
-        "gunicorn3",
-        "libssl-dev",
-        "libvirt-daemon-system",
-        "libvirt-dev",
-        "net-tools",
-        "prometheus-node-exporter",
-        "pwgen",
-        "python-libvirt",
-        "python3-libvirt",
-        "qemu-kvm",
-        "unzip",
-      ]
+    name: "{{ shakenfist_deps }}"
     state: latest
 
 - name: Disable dnsmasq

--- a/ansible/tasks/distro-check.yml
+++ b/ansible/tasks/distro-check.yml
@@ -1,0 +1,6 @@
+---
+- name: Warn if unsupported distro
+  pause:
+    prompt: "\nWARNING: Only Ubuntu is supported at present ({{ ansible_distribution }} detected), this will probably fail"
+    seconds: 30
+  when: ansible_distribution.split(' ', 1)[0] | lower != "ubuntu"

--- a/ansible/vars/main.yml
+++ b/ansible/vars/main.yml
@@ -1,0 +1,20 @@
+---
+# Defaults are Ubuntu specific
+shakenfist_deps:
+  - arping
+  - bridge-utils
+  - cpu-checker
+  - dnsmasq
+  - dnsutils
+  - etcd-client
+  - git
+  - "{{ 'gunicorn3' if ansible_distribution_version < '20.04' else 'gunicorn' }}"
+  - libssl-dev
+  - libvirt-daemon-system
+  - libvirt-dev
+  - net-tools
+  - prometheus-node-exporter
+  - pwgen
+  - python3-libvirt
+  - qemu-kvm
+  - unzip


### PR DESCRIPTION
The current list of packages is hard-coded and fails when deploying to
Ubuntu Focal which is Python 3 only and has some renamed packages (such
as gunicorn3 -> gunicorn). The Ansible PPA is also not required on
Focal, nor is it available and so actually fails.

This patch skips adding the Ansible PPA on Focal or later release and
also turns the list of dependencies into a variable, stored in a distro
specific vars file (vars/ubuntu.yml). This makes it easier to put logic
into the list as dependencies change in the future and also allows users
to override the package list if needed, without modifying the code.

It has an added benefit of making it easier to support other distros in
the future, if so desired.

This also removes the `python-libvirt` for all releases, as it's Python 2 and I don't think it's needed, but please correct me if I'm wrong...