### PR TITLE
ensure deps for git based deploy are installed

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -8,6 +8,17 @@
   tasks:
     - include_tasks: tasks/distro-check.yml
 
+    - name: Load default vars
+      include_vars: main.yml
+
+    - name: Install deps for Git based deploy
+      apt:
+        name: "{{ shakenfist_deps_git_deploy }}"
+        state: latest
+        update_cache: yes
+      when: release == "git"
+      become: yes
+
     - name: Ensure unit tests pass
       shell:
         cmd: tox -epy3

--- a/ansible/vars/main.yml
+++ b/ansible/vars/main.yml
@@ -18,3 +18,9 @@ shakenfist_deps:
   - python3-libvirt
   - qemu-kvm
   - unzip
+
+shakenfist_deps_git_deploy:
+  - build-essential
+  - python3-dev
+  - python3-wheel
+  - tox


### PR DESCRIPTION
When installing shakenfist from local Git instead of pip, wheels need to
be built and tox tests run. In order for this to be successful it needs
to compile packages.

This patch ensures that the required dependencies, such as build-essential and
Python headers, are installed.