### PR TITLE
Feature remove submodules and use spinouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 # Terraform
 .terraform/
 *.tfstate*
+
+# Git repos
+gitrepos/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shakenfist"]
-	path = shakenfist
-	url = https://github.com/shakenfist/shakenfist

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ configuration found in deploy/ansible/terraform/<cloud> where "cloud" is one of 
 ```bash
 sudo apt-get install ansible tox pwgen build-essential python3-dev python3-wheel
 git clone https://github.com/shakenfist/deploy
-cd deploy/ansible
 ansible-galaxy install andrewrothstein.etcd-cluster andrewrothstein.terraform andrewrothstein.go
 ```
 
@@ -72,7 +71,8 @@ $ cat ~/sf-deploys/cbr-remote.sh
 #!/bin/bash
 
 export CLOUD=metal
-export VARIABLES="ADMIN_PASSWORD=p4ssw0rd FLOATING_IP_BLOCK=192.168.20.0/24"
+export ADMIN_PASSWORD="p4ssw0rd"
+export FLOATING_IP_BLOCK="192.168.20.0/24"
 export BOOTDELAY=0
 
 # Tests are not currently safe for clusters whose data you are fond of

--- a/README.md
+++ b/README.md
@@ -1,30 +1,34 @@
 Shaken Fist: Opinionated to the point of being impolite
 =======================================================
 
-What is this?
--------------
+## What is this?
 
-Shaken Fist is a deliberately minimal cloud. You can read more about Shaken Fist at https://github.com/shakenfist/shakenfist --
-this repository is the deployment and CI tooling for the project, and therefore not a great place to start your journey.
+Shaken Fist is a deliberately minimal cloud. You can read more about Shaken Fist at https://github.com/shakenfist/shakenfist
+and shakenfist.com -- this repository is the deployment and CI tooling for the project, and therefore not a great place to
+start your journey.
 
-Installation
-------------
+## Installation
 
-Build an acceptable deployment, noting that only Ubuntu is supported.
+Build an acceptable deployment, noting that only Ubuntu is supported. Deployments are based on Hashicorp terraform
+configuration found in deploy/ansible/terraform/<cloud> where "cloud" is one of the following at the time of writing:
 
-## Common first steps
+* aws: Amazon EC2 bare metal (3 node cluster)
+* aws-single-node: Amazon EC2 bare metal (1 node cluster), note that the CI tests will not pass on a single node cluster
+* gcp: Google cloud, using nested virtualization (see additional steps below). **This deployment option is not for production use because of its lack of bare metal support and low MTUs affecting virtual network performance. We mainly use it for CI testing.**
+* metal: Baremetal provisioned outside of terraform
+* openstack: OpenStack, using nested virtualization
+* shakenfist: Shaken Fist can self host, this is useful for CI for example
+
+### Common first steps
 
 ```bash
 sudo apt-get install ansible tox pwgen build-essential python3-dev python3-wheel
 git clone https://github.com/shakenfist/deploy
-cd deploy
-git submodule init
-git submodule update
-cd ansible
+cd deploy/ansible
 ansible-galaxy install andrewrothstein.etcd-cluster andrewrothstein.terraform andrewrothstein.go
 ```
 
-## Google Cloud
+### Google Cloud additional first steps
 
 On Google Cloud, you need to enable nested virt first:
 
@@ -37,41 +41,7 @@ gcloud compute images create sf-image \
   --licenses "https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
 ```
 
-Configure deployment parameters and deploy
-
-```bash
-cd ansible
-export METAL_IP_SF1="192.168.72.240"
-export METAL_IP_SF2="192.168.72.230"
-export METAL_IP_SF3="192.168.72.242"
-./deployandtest.sh
-```
-
-## OpenStack Deployment
-
-Configure deployment parameters and deploy
-
-```bash
-cd ansible
-export OS_SSH_KEY_NAME="and-arwen"
-export OS_FLAVOR_NAME="2C-4GB-50GB"
-export OS_EXTERNAL_NET_NAME="ext-net"
-./deployandtest.sh
-```
-
-## Bare Metal Deployment
-
-Configure deployment parameters and deploy
-
-```bash
-cd ansible
-export METAL_IP_SF1="192.168.72.240"
-export METAL_IP_SF2="192.168.72.230"
-export METAL_IP_SF3="192.168.72.242"
-./deployandtest.sh
-```
-
-### VMWare ESXi
+### VMWare ESXi additional first steps
 
 The "metal" installation option can be used to create a test cluster on VMWare ESXi hypervisors.
 
@@ -84,3 +54,56 @@ Hardware virtualization:
 Performance counters:
     Enable virtualized CPU performance counters
 ```
+
+### Other caveats
+
+The installer will also enforce the following sanity checks:
+
+* That KVM will operate on your machines. This is generally fine unless you're using virtual machines at which point nested virtualization needs to be enabled.
+* That your network interface MTU is greater than 2,000 bytes. This is required because the VXLAN mesh our virtual networks use add overhead to packets and a standard MTU of 1500 bytes for the physical network will result in packets being fragmented too frequently on the virtual networks. You can set a higher MTU if you desire, I generally select 9,000 bytes.
+
+### Deployment
+
+Each deployment takes slight different arguments. I tend to write a small shell script to wrap these up for
+convenience. Here's an example for a baremetal deployment:
+
+```bash
+$ cat ~/sf-deploys/cbr-remote.sh 
+#!/bin/bash
+
+export CLOUD=metal
+export VARIABLES="ADMIN_PASSWORD=p4ssw0rd FLOATING_IP_BLOCK=192.168.20.0/24"
+export BOOTDELAY=0
+
+# Tests are not currently safe for clusters whose data you are fond of
+export SKIP_SF_TESTS=1
+
+./deployandtest.sh
+```
+
+I then execute that script from the deploy/ansible directory to do a deployment or upgrade. Note that running the
+CI suite will destroy the contents of your cloud so be sure to use SKIP_SF_TESTS if you're upgrading a cluster
+with real users.
+
+### Deployment variables
+
+| Option | Terraform definition | Description |
+|--------|----------------------|-------------|
+| CLOUD | All | The terraform definition to use |
+| ADMIN_PASSWORD | All | The admin password for the cloud once installed |
+| FLOATING_IP_BLOCK | All | The IP range to use for the floating network |
+| BOOTDELAY | All | How long to wait for terraform deployed instances to boot before continuing with install, in minutes |
+| SKIP_SF_TEST | All | Set to 1 to skip running destructive testing of the cloud |
+| AWS_REGION | aws, aws-single-node | The AWS region to deploy in |
+| AWS_AVAILABILITY_ZONE | aws, aws-single-node | The AWS availability zone to deploy in |
+| AWS_VPC_ID | aws, aws-single-node | The AWS VPC to use |
+| AWS_SSH_KEY_NAME | aws, aws-single-node | The name of an SSH key in the AWS region to use for ansible |
+| GCP_PROJECT | gcp | The GCP project id to deploy in |
+| OS_SSH_KEY_NAME | openstack | The name of a SSH key in the OpenStack cloud to use for ansible |
+| OS_FLAVOR_NAME | openstack | The OpenStack flavor to use for instances |
+| OS_EXTERNAL_NET_NAME | openstack | The UUID of an OpenStack network with internet access |
+| METAL_IP_SF1 | metal | The IP address of a baremetal machine |
+| METAL_IP_SF2 | metal | The IP address of a baremetal machine |
+| METAL_IP_SF3 | metal | The IP address of a baremetal machine |
+| SHAKENFIST_KEY | shakenfist | The authentication key for a user on the shakenfist cluster to deploy in |
+| SHAKENFIST_SSH_KEY | shakenfist | The _path_ to a SSH key to use for ansible |

--- a/ansible-ci/library
+++ b/ansible-ci/library
@@ -1,1 +1,1 @@
-../shakenfist/ansible-modules
+../gitrepos/ansible-modules

--- a/ansible-ci/pretest.yml
+++ b/ansible-ci/pretest.yml
@@ -48,11 +48,3 @@
         owner: root
         group: root
         mode: u=rx
-
-    - name: Copy cleanup script
-      copy:
-        src: ../shakenfist/cleanup.sh
-        dest: /srv/shakenfist/cleanup.sh
-        owner: root
-        group: root
-        mode: u=rx,g=rx,o=rx

--- a/ansible-ci/tests/_setup.yml
+++ b/ansible-ci/tests/_setup.yml
@@ -21,7 +21,36 @@
     content: |
       #!/bin/bash -e
 
-      /srv/shakenfist/cleanup.sh
+      . /etc/sf/sfrc
+
+      for vm in `virsh list --all | tr -s " " | grep "sf:" | cut -f 3 -d " "`
+      do
+          virsh destroy $vm
+          virsh undefine $vm
+      done
+
+      rm -rf /srv/shakenfist/instances
+      rm -rf /srv/shakenfist/snapshots
+      rm -rf /srv/shakenfist/dhcp
+      rm -rf /srv/shakenfist/image_cache/*.qcow2.*G
+
+      ip link del phy-br-ens4
+      for i in `seq 100`
+      do
+        ip link del br-vxlan-$i
+        ip link del vxlan-$i
+        ip link del phy-$i-o
+        ip link del veth-$i-o
+      done
+
+      if [ -e /var/run/netns ]
+      then
+        for ns in `ls /var/run/netns`
+        do
+          ip netns del $ns
+        done
+      fi
+
       [ `virsh list | grep running | wc -l` -eq 0 ]
       [ `ifconfig | grep -c br-vxlan` -eq 0 ]
 

--- a/ansible-ci/tests/_setup.yml
+++ b/ansible-ci/tests/_setup.yml
@@ -34,13 +34,12 @@
       rm -rf /srv/shakenfist/dhcp
       rm -rf /srv/shakenfist/image_cache/*.qcow2.*G
 
-      ip link del phy-br-ens4
       for i in `seq 100`
       do
-        ip link del br-vxlan-$i
-        ip link del vxlan-$i
-        ip link del phy-$i-o
-        ip link del veth-$i-o
+        ip link del br-vxlan-$i || true
+        ip link del vxlan-$i || true
+        ip link del phy-$i-o || true
+        ip link del veth-$i-o || true
       done
 
       if [ -e /var/run/netns ]

--- a/ansible-ci/tests/library
+++ b/ansible-ci/tests/library
@@ -1,1 +1,1 @@
-../../shakenfist/ansible-modules
+../../gitrepos/ansible-modules

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -116,7 +116,7 @@
     - name: Abort if default interface MTU is too low
       fail:
         msg: "Node MTU is too low."
-      when: node_mtu|int < 2000
+      when: node_mtu|int < 2000 and cloud != "gcp"
 
     - name: Make /srv/shakenfist/
       file:
@@ -157,7 +157,7 @@
 
     - name: Copy shakenfist
       synchronize:
-        src: ../shakenfist/dist/{{hostvars['localhost']['wheel_path']}}
+        src: ../gitrepos/shakenfist/dist/{{hostvars['localhost']['wheel_path']}}
         dest: /srv/shakenfist/
       when: release == "git"
 

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -11,7 +11,21 @@
     - name: Load default vars
       include_vars: main.yml
 
-    - include_tasks: tasks/build-wheel.yml
+    - include: tasks/build-wheel.yml
+        repo="shakenfist"
+        package="shakenfist"
+      when: release == "git"
+
+    - include: tasks/build-wheel.yml
+        repo="client-python"
+        package="shakenfist_client"
+      when: release == "git"
+
+    - name: Log wheel details
+      debug:
+        msg:
+          - "Shakenfist wheel is: {{hostvars['localhost']['shakenfist_wheel_path']}}"
+          - "Shakenfist client wheel is: {{hostvars['localhost']['shakenfist_client_wheel_path']}}"
 
     - name: Generate a random auth secret
       set_fact:
@@ -152,27 +166,43 @@
 
     - name: Remove old wheels
       file:
-        path: /srv/shakenfist/shakenfist-*-py3-none-any.whl
+        path: /srv/shakenfist/shakenfist*-py3-none-any.whl
         state: absent
 
     - name: Copy shakenfist
       synchronize:
-        src: ../gitrepos/shakenfist/dist/{{hostvars['localhost']['wheel_path']}}
+        src: ../gitrepos/shakenfist/dist/{{hostvars['localhost']['shakenfist_wheel_path']}}
+        dest: /srv/shakenfist/
+      when: release == "git"
+
+    - name: Copy shakenfist client
+      synchronize:
+        src: ../gitrepos/client-python/dist/{{hostvars['localhost']['shakenfist_client_wheel_path']}}
         dest: /srv/shakenfist/
       when: release == "git"
 
     - name: Uninstall shakenfist, if present
-      command: pip3 uninstall -y shakenfist
+      command: pip3 uninstall -y shakenfist shakenfist-client
       ignore_errors: True
 
     - name: Install shakenfist
-      command: pip3 install {{hostvars['localhost']['wheel_path']}}
+      command: pip3 install {{hostvars['localhost']['shakenfist_wheel_path']}}
+      args:
+        chdir: /srv/shakenfist/
+      when: release == "git"
+
+    - name: Install shakenfist client
+      command: pip3 install {{hostvars['localhost']['shakenfist_client_wheel_path']}}
       args:
         chdir: /srv/shakenfist/
       when: release == "git"
 
     - name: Install shakenfist from pypi
       command: pip3 install shakenfist=={{release}}
+      when: release != "git"
+
+    - name: Install shakenfist client from pypi
+      command: pip3 install shakenfist-client=={{release}}
       when: release != "git"
 
     - name: Create config directory

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -11,6 +11,7 @@ localhost ansible_connection=local
 
 [allsf:vars]
   ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+  ansible_python_interpreter='/usr/bin/python3'
 
 [etcd:children]
   allsf

--- a/ansible/library
+++ b/ansible/library
@@ -1,1 +1,1 @@
-../shakenfist/ansible-modules
+../gitrepos/ansible-modules

--- a/ansible/tasks/build-wheel.yml
+++ b/ansible/tasks/build-wheel.yml
@@ -2,29 +2,29 @@
 - name: Ensure unit tests pass
   shell:
     cmd: tox -epy3
-    chdir: ../shakenfist
+    chdir: ../gitrepos/shakenfist
   when: release == "git"
 
 - name: Clear out old wheels
   file:
-    path: ../shakenfist/dist
+    path: ../gitrepos/shakenfist/dist
     state: absent
   when: release == "git"
 
 - name: Ensure we have a local dist directory
   file:
-    path: ../shakenfist/dist
+    path: ../gitrepos/shakenfist/dist
     state: directory
   when: release == "git"
 
 - name: Build a wheel for shakenfist
   shell:
     cmd: python3 setup.py sdist bdist_wheel
-    chdir: ../shakenfist
+    chdir: ../gitrepos/shakenfist
   when: release == "git"
 
 - name: Find the most recent wheel for shakenfist
-  shell: ls -rt ../shakenfist/dist/*.whl | tail -1 | sed 's/\.\.\/shakenfist\/dist\///'
+  shell: ls -rt ../gitrepos/shakenfist/dist/*.whl | tail -1 | sed 's/\.\.\/gitrepos\/shakenfist\/dist\///'
   register: wheel_complex
   when: release == "git"
 

--- a/ansible/tasks/build-wheel.yml
+++ b/ansible/tasks/build-wheel.yml
@@ -2,38 +2,27 @@
 - name: Ensure unit tests pass
   shell:
     cmd: tox -epy3
-    chdir: ../gitrepos/shakenfist
-  when: release == "git"
+    chdir: ../gitrepos/{{repo}}
 
 - name: Clear out old wheels
   file:
-    path: ../gitrepos/shakenfist/dist
+    path: ../gitrepos/{{repo}}/dist
     state: absent
-  when: release == "git"
 
 - name: Ensure we have a local dist directory
   file:
-    path: ../gitrepos/shakenfist/dist
+    path: ../gitrepos/{{repo}}/dist
     state: directory
-  when: release == "git"
 
-- name: Build a wheel for shakenfist
+- name: Build a wheel for {{repo}}
   shell:
     cmd: python3 setup.py sdist bdist_wheel
-    chdir: ../gitrepos/shakenfist
-  when: release == "git"
+    chdir: ../gitrepos/{{repo}}
 
-- name: Find the most recent wheel for shakenfist
-  shell: ls -rt ../gitrepos/shakenfist/dist/*.whl | tail -1 | sed 's/\.\.\/gitrepos\/shakenfist\/dist\///'
+- name: Find the most recent wheel for {{repo}}
+  shell: ls -rt ../gitrepos/{{repo}}/dist/{{package}}-*.whl | tail -1 | sed 's/\.\.\/gitrepos\/{{repo}}\/dist\///'
   register: wheel_complex
-  when: release == "git"
 
 - name: Extract wheel filename
   set_fact:
-    wheel_path: "{{wheel_complex.stdout}}"
-  when: release == "git"
-
-- name: Log wheel details
-  debug:
-    msg: "Wheel is: {{hostvars['localhost']['wheel_path']}}"
-  when: release == "git"
+    "{{package}}_wheel_path": "{{wheel_complex.stdout}}"

--- a/shakenfist_ci/tests/test_state_changes.py
+++ b/shakenfist_ci/tests/test_state_changes.py
@@ -45,6 +45,7 @@ class TestStateChanges(base.BaseTestCase):
 
         self.assertIsNotNone(inst['uuid'])
         last_prompt = self._await_login_prompt(inst['uuid'])
+        self._test_ping(self.net['uuid'], ip, True)
 
         # Soft reboot
         self.test_client.reboot_instance(inst['uuid'])


### PR DESCRIPTION
Hi. This patch is part of a series which spins out the ansible modules and python client into their own git repositories, rejigs the deployer to handle that change, adds richer git release descriptions, and fixes some minor bugs along the way. Please review the changes in the following order:

 - ansible-module spin out: https://github.com/shakenfist/ansible-modules/pull/1
 - client-python spin out: https://github.com/shakenfist/client-python/pull/1
 - deploy updates to use spin outs and support fancier git deploys: https://github.com/shakenfist/deploy/pull/58 (this PR)
 - removal of redundant code from shakenfist: https://github.com/shakenfist/shakenfist/pull/300

Fixes #54.