### PR TITLE
Change default sound card

### DIFF
--- a/ansible/files/libvirt.tmpl
+++ b/ansible/files/libvirt.tmpl
@@ -79,7 +79,7 @@
       <listen type='address' address='0.0.0.0'/>
     </graphics>
 
-    <sound model='es1370'/>
+    <sound model='ich6'/>
 
     <input type='mouse' bus='ps2'/>
     <input type='keyboard' bus='ps2'/>


### PR DESCRIPTION
Change sound card from Ensoniq (used by old guys) to something from the modern era - Intel HDA audio.
This might break a very old MSDOS app trying to use the sound card. (Not the target market?)
This could be selectable in the future, but I don't really see the need?
