### PR TITLE
Fix vars for etcd-cluster role

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -223,12 +223,13 @@
 
 # Install etcd on all nodes, with members of etcd-master being voting nodes
 - hosts: etcd
+  vars:
+    etcd_secure: False
+    etcd_cluster_name: shakenfist
+    etcd_enable_v2: False
+    etcd_master_group_name: etcd_master
   roles:
     - role: andrewrothstein.etcd-cluster
-      etcd_secure: False
-      etcd_cluster_name: shakenfist
-      etcd_enable_v2: False
-      etcd_master_group_name: etcd_master
       when: mode == "deploy"
 
 - hosts: allsf

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -223,14 +223,14 @@
 
 # Install etcd on all nodes, with members of etcd-master being voting nodes
 - hosts: etcd
-  vars:
-    etcd_secure: False
-    etcd_cluster_name: shakenfist
-    etcd_enable_v2: False
-    etcd_master_group_name: etcd_master
   roles:
     - role: andrewrothstein.etcd-cluster
       when: mode == "deploy"
+      vars:
+        etcd_secure: False
+        etcd_cluster_name: shakenfist
+        etcd_enable_v2: False
+        etcd_master_group_name: etcd_master
 
 - hosts: allsf
   any_errors_fatal: true


### PR DESCRIPTION
Fix typo where variables for etcd-cluster weren't nested under a `vars` key

Fixes #76 